### PR TITLE
Cleaned up lightkurve based python code.

### DIFF
--- a/SAPlightcurve.py
+++ b/SAPlightcurve.py
@@ -1,0 +1,102 @@
+# Python3 and pip3
+# Reqd packages: numpy, scipy, lightkurve (and others) 
+# LightKurve based code to read pixel data of targets and generate light curve 
+# using aperture defined in target file.
+# Ref:
+# Pixel data for C13 targets can be downloaded from 
+#    https://archive.stsci.edu/pub/k2/target_pixel_files/c13/ (Or this program 
+#    can automatically download based on EPIC ID
+# LightKurve SW tutorials: https://docs.lightkurve.org/tutorials/index.html
+#    This snippet uses code from the "LightKurve API" tutorial
+# However, Light curves can be got for C13 from 
+#    https://archive.stsci.edu/pub/k2/lightcurves/c13/
+
+import sys  
+import os
+import matplotlib.pyplot as plt
+import astropy.units as u
+from lightkurve import KeplerTargetPixelFile
+from lightkurve import search_lightcurvefile
+from lightkurve import search_targetpixelfile
+
+#Methods
+
+#print metadata
+def print_metadata():
+    # print some metadata
+    print("Info on pixel data")
+    print("Mission: ", tpf.mission)
+    print("Quarter: ", tpf.quarter)
+    print("Time: ", tpf.astropy_time.utc.iso)
+    return
+
+#print normalized LC w/o outliers
+def plot_show_normalNoOutliersLC():
+    pltTitle = 'Light Curve of ' + sys.argv[1]
+    lc.remove_outliers().normalize().plot(title=pltTitle)
+    #set title and display plot
+    plt.title (pltTitle)
+    plt.show()
+    return
+
+def plot_show_ampVsFreq():
+    pg.plot()
+    plt.title ('Amplitude vs Freq: Periodogram of ' + sys.argv[1])
+    plt.show()
+    return
+
+def plot_show_ampVsPeriodLog():
+    pg.plot(view='period', scale='log')
+    #set title and display plot
+    plt.title ('Amplitude vs Period: Periodogram of ' + sys.argv[1])
+    plt.show()
+    return
+
+def plot_show_flux():
+    #get period of max power
+    period = pg.period_at_max_power
+    print('Best period: {}'.format(period))
+    lc.fold(period.value).scatter();
+    #set title and display plot
+    plt.title ('Max Power (Flux) of ' + sys.argv[1])
+    plt.show()
+    return
+
+#Main code
+if len(sys.argv) < 2:
+    print ("Usage: SAPlightcurve <epicID_of_target>")
+    sys.exit()
+
+epicID = int(sys.argv[1])
+
+if epicID is None:
+    print ("No epicID give - exiting..")
+    sys.exit()
+else:
+    print ("Going to download pixel data for ", epicID)
+
+tpf = search_targetpixelfile(epicID).download()
+if tpf is None:
+    print ("Unable to download TPF for ", epicID)
+    print ("Exiting..")
+else:
+    # save pixel data in FITS file
+    cwd = os.getcwd()
+    fits_fname = str(epicID)+(".fits")
+    output_fn=cwd+"/"+fits_fname
+    tpf.to_fits(output_fn, overwrite=True)
+    print ('Saved FITS file at: ', output_fn)
+
+    print_metadata()
+
+    #generate the LC 
+    lc = tpf.to_lightcurve(aperture_mask=tpf.pipeline_mask)
+
+    #plot and show LC
+    plot_show_normalNoOutliersLC()
+
+    #plot and show someperiodograms
+    pg = lc.to_periodogram(oversample_factor=1)
+    plot_show_ampVsFreq()
+    plot_show_ampVsPeriodLog()
+    plot_show_flux()


### PR DESCRIPTION
Editing ipynb's directly in github may need further investigation.  Uploading the py code in meantime.
Side note on local instance of matlib.pyplot (not completely resolved - but not sure if we need to spend more time)

Trying to undestand why and how local pyplot instance is needed/used:
------------
1. lightkurve's plot() method returns an axes object, that is to be displayed through show() method.
2. lightkurve also has a local instance of pyplot
3. lightkurve does not itself call show(), and is upto client app to call show().
4. Unanswered q: how is axes object returned by p)lot() method visible to client instance of pyplot?

Alterantives I tried and work:
1. Modified kightkurve's plot() method to set title and to show it's generated axes data.  This is available (local) at /Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/lightkurve/lightcurve.py.plot+show
2. Removed calls to pyplot.title() and pyplot.show() from lightkurve client aopp.
However, above seems unnecessary, and we should go with code as is.